### PR TITLE
Update species-gen.py

### DIFF
--- a/crawl-ref/source/util/species-gen.py
+++ b/crawl-ref/source/util/species-gen.py
@@ -17,7 +17,7 @@ def quote_or_nullptr(key, d):
     else:
         return 'nullptr'
 
-class Species(collections.MutableMapping):
+class Species(collections.abc.MutableMapping):
     """Parser for YAML definition files.
 
     If any YAML content is invalid, the relevant parser function below should


### PR DESCRIPTION
The attribute MutableMapping from the module collections got moved into collections.abc in Python 3.10

Related:
 - https://github.com/kimjoy2002/crawl/pull/607
 - https://github.com/refracta/dcss-webtiles-server/actions/runs/9200733674/job/25307770874#step:4:8757
 - https://stackoverflow.com/questions/70943244/attributeerror-module-collections-has-no-attribute-mutablemapping